### PR TITLE
Get rolling with Speedata Publisher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ NPX ?= npx
 PAGEDJS ?= $(NPX) pagedjs-cli
 SED ?= sed
 SILE ?= sile
+SPEEDATA ?= sp
 TERA ?= tera
 TOMLQ ?= tomlq
 TYPST ?= typst
@@ -26,6 +27,8 @@ BASE_URL = /
 PAGEDJS_ARGS = -i $< -o $@
 
 SILE_ARGS = -o $@ $<
+
+SPEEDATA_ARGS = --dummy --layout $< --jobname $*-speedata
 
 TYPST_ARGS = compile $< $@
 
@@ -69,6 +72,9 @@ node_modules:
 
 %-sile.pdf %-sile.toml: %/sile.xml
 	$(call make_manifest,$(SILE) $(SILE_ARGS))
+
+%-speedata.pdf %-speedata.toml: %/speedata.xml
+	$(call make_manifest,$(SPEEDATA) $(SPEEDATA_ARGS))
 
 %-typst.pdf %-typst.toml: %/typst.typ
 	$(call make_manifest,$(TYPST) $(TYPST_ARGS))

--- a/content/hello-world.md
+++ b/content/hello-world.md
@@ -1,7 +1,7 @@
 +++
 title = "Hello World!"
 description = "Your most basic greeting."
-extra.typesetters = [ "sile", "typst", "xelatex", "pagedjs", "weasyprint" ]
+extra.typesetters = [ "sile", "typst", "xelatex", "pagedjs", "weasyprint", "speedata" ]
 +++
 
 Just the simplest way to get a phrase onto a numbered page.

--- a/data/hello-world/speedata.xml
+++ b/data/hello-world/speedata.xml
@@ -2,6 +2,22 @@
   xmlns="urn:speedata.de:2009/publisher/en"
   xmlns:sd="urn:speedata:2009/publisher/functions/en">
 
+  <Pagetype name="page" test="true()">
+    <AtPageShipout>
+      <PlaceObject column="1" row="{sd:number-of-rows() - 1}">
+        <Table stretch="max">
+          <Tr>
+            <Td align="center">
+              <Paragraph>
+                <Value select="sd:current-page()"/>
+              </Paragraph>
+            </Td>
+          </Tr>
+        </Table>
+      </PlaceObject>
+    </AtPageShipout>
+  </Pagetype>
+
   <Record element="data">
     <PlaceObject>
       <Textblock>

--- a/data/hello-world/speedata.xml
+++ b/data/hello-world/speedata.xml
@@ -1,0 +1,14 @@
+<Layout
+  xmlns="urn:speedata.de:2009/publisher/en"
+  xmlns:sd="urn:speedata:2009/publisher/functions/en">
+
+  <Record element="data">
+    <PlaceObject>
+      <Textblock>
+        <Paragraph>
+          <Value>Hello World</Value>
+        </Paragraph>
+      </Textblock>
+    </PlaceObject>
+  </Record>
+</Layout>

--- a/templates/page.html
+++ b/templates/page.html
@@ -27,7 +27,7 @@
     </p>
 
     <h4 class="title is-4">Input document</h4>
-    {% set source = load_data(path=manifest.src) %}
+    {% set source = load_data(path=manifest.src, format="plain") %}
     <pre>{{ source }}</pre>
 
     <h4 class="title is-4">Render command</h4>


### PR DESCRIPTION
This includes a working example with Speedata, but it currently only works for me locally with a modified path to include the upstream binary project bundle. There doesn't seem to be any distro packaging at all much less a Nix flake or even an install target ([reported upstream](https://github.com/speedata/publisher/issues/551)) or release tags ([reported upstream](https://github.com/speedata/publisher/issues/550)) to get started making one from source.

I'm not quite sure how we'll go about getting this running in CI yet, hence the draft mode until that part gets figured out.

This also uses dummy data because I haven't figured out how we'll layout multiple input files per example here yet, but whet that is worked out the data element should move to a separate file to be idiomatic of Speedata Publisher's typical workflow.