### PR TITLE
Add SATySFi typesetter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MAGICK ?= magick
 NPM ?= npm
 NPX ?= npx
 PAGEDJS ?= $(NPX) pagedjs-cli
+SATYSFI ?= satysfi
 SED ?= sed
 SILE ?= sile
 TERA ?= tera
@@ -24,6 +25,8 @@ ZOLA ?= zola
 BASE_URL = /
 
 PAGEDJS_ARGS = -i $< -o $@
+
+SATYSFI_ARGS = $< -o $@
 
 SILE_ARGS = -o $@ $<
 
@@ -63,6 +66,9 @@ node_modules:
 
 %-pagedjs.pdf %-pagedjs.toml: %/pagedjs.html
 	$(call make_manifest,$(PAGEDJS) $(PAGEDJS_ARGS))
+
+%-satysfi.pdf %-saty.toml: %/satysfi.saty
+	$(call make_manifest,$(SATYSFI) $(SATYSFI_ARGS))
 
 %-sile.pdf %-sile.toml: %/sile.sil
 	$(call make_manifest,$(SILE) $(SILE_ARGS))

--- a/content/hello-world.md
+++ b/content/hello-world.md
@@ -1,7 +1,7 @@
 +++
 title = "Hello World!"
 description = "Your most basic greeting."
-extra.typesetters = [ "sile", "typst", "xelatex", "pagedjs", "weasyprint" ]
+extra.typesetters = [ "sile", "typst", "xelatex", "satysfi", "pagedjs", "weasyprint" ]
 +++
 
 Just the simplest way to get a phrase onto a numbered page.

--- a/data/hello-world/satysfi.saty
+++ b/data/hello-world/satysfi.saty
@@ -1,0 +1,10 @@
+@require: stdja
+
+document(|
+  title = {};
+  author = {};
+  show-title = false;
+  show-toc = false;
+|) '<
+  +p{Hello World}
+>

--- a/data/hello-world/satysfi.saty
+++ b/data/hello-world/satysfi.saty
@@ -1,10 +1,8 @@
-@require: stdja
+@require: stdjareport
 
 document(|
-  title = {};
-  author = {};
-  show-title = false;
-  show-toc = false;
+	title = {};
+	author = {};
 |) '<
-  +p{Hello World}
+	+p{Hello World}
 >

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             imagemagick
             libertinus
             nodejs
+            satysfi
             sile
             stix-two
             teracli.defaultPackage.${system}

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -48,5 +48,8 @@
     <li>
       <a href="https://pagedjs.org">paged.js</a>
     </li>
+    <li>
+      <a href="https://github.com/gfngfn/SATySFi">SATySFi</a>
+    </li>
   </ul>
 </aside>


### PR DESCRIPTION
This adds support for SATySFI. The hello world example is working, but before adding this I would like to figure out the proper document package to use that isn't defaulting to Japaneese. Also getting *rid* of the header bar and other features not output by default in most typesetters would be nice, but that probably has to do with the document class as well.
