### PR TITLE
Use siunitx to typeset the geographic dimensions

### DIFF
--- a/data/prime-symbol/xelatex.tex
+++ b/data/prime-symbol/xelatex.tex
@@ -15,13 +15,19 @@ Math mode manners:
 \setmathfont{STIX Two Math}
 \[\mathlarger{\begin{aligned}
 	f(x) & = a\prime + b\dprime + c\trprime \\
-	f\prime(x) & = x^{2} + 1
+	f(x) & = a^{\prime} + b^{\dprime} + c^{\trprime} \\
+	f(x) & = a' + b'' + c''' \\
+	f\prime(x) & = x^{2} + 1\\
+	f'(x) & = x^{2} + 1
 \end{aligned}}\]
 
 \setmathfont{Libertinus Math}
 \[\mathlarger{\begin{aligned}
 	f(x) & = a\prime + b\dprime + c\trprime \\
-	f\prime(x) & = x^{2} + 1
+	f(x) & = a^{\prime} + b^{\dprime} + c^{\trprime} \\
+	f(x) & = a' + b'' + c''' \\
+	f\prime(x) & = x^{2} + 1\\
+	f'(x) & = x^{2} + 1
 \end{aligned}}\]
 
 Prose poses problems:

--- a/data/prime-symbol/xelatex.tex
+++ b/data/prime-symbol/xelatex.tex
@@ -6,6 +6,7 @@
 \usepackage{fontspec}
 \usepackage{relsize}
 \usepackage{unicode-math}
+\usepackage{siunitx}
 \begin{document}
 \fontsize{12}{16}
 \selectfont
@@ -29,7 +30,7 @@ Prose poses problems:
 \raggedright{
 	60*10'16"N 24*55'52"E (plain)\break
 	60°10′16″N 24°55′52″E (unicode)\break
-	60\textdegree{}10\ensuremath{\prime}16\ensuremath{\dprime}N 24\textdegree{}55\ensuremath{\prime}52\ensuremath{\dprime}E (native)
+	\ang{60;10;16}N \ang{24;55;52}E (native)
 }
 
 \end{document}


### PR DESCRIPTION
As we discussed on [Mastodon](https://fosstodon.org/@michal_h21/111703039014605012), here is a change that uses the Siunitx package to typeset the geographic dimensions. 