### PR TITLE
Variant limits in math

### DIFF
--- a/content/varlimits.md
+++ b/content/varlimits.md
@@ -1,0 +1,16 @@
++++
+title = "Variant limits"
+description = "Those limits with a little extra flair"
+extra.typesetters = [ "sile", "xelatex" ]
++++
+
+Variants for superior, inferior, projective, and injective limits are an interesting challenge for typesetting engines with mathematical capabilities.
+
+They have both a subscript expression and a stretchy symbol (an arrow or a bar) that indicates the direction and nature of the limit.
+
+The symbol is stacked below or above the limit.
+
+In display mode, the expression is below the limit.
+
+In inline mode, the expression is on the right of the limit, but the symbol remains above or below the limit.
+So the symbol is not _moveable,_ while the expression is, depending on the context.

--- a/data/varlimits/sile.sil
+++ b/data/varlimits/sile.sil
@@ -1,0 +1,33 @@
+\begin[papersize=a7]{document}
+\nofolios
+\neverindent
+\use[module=packages.math]
+\font[size=12pt]
+\set[parameter=math.font.family,value=Libertinus Math]
+\set[parameter=math.font.size,value=12]
+
+\begin[mode=display]{math}
+  \projlim_{i \in I} A_i = \varprojlim_{i \in I} A_i
+\end{math}
+
+Inline: \math{\projlim_{i \in I} A_i = \varprojlim_{i \in I} A_i}
+
+\begin[mode=display]{math}
+  \injlim_{i \in I} A_i = \varinjlim_{i \in I} A_i
+\end{math}
+
+Inline: \math{\injlim_{i \in I} A_i = \varinjlim_{i \in I} A_i}
+
+\begin[mode=display]{math}
+  \limsup_{n \to \infty} a_n = \varlimsup_{n \to \infty} a_n
+\end{math}
+
+Inline: \math{\limsup_{n \to \infty} a_n = \varlimsup_{n \to \infty} a_n}
+
+\begin[mode=display]{math}
+  \liminf_{n \to \infty} a_n = \varliminf_{n \to \infty} a_n
+\end{math}
+
+Inline: \math{\liminf_{n \to \infty} a_n = \varliminf_{n \to \infty} a_n}
+
+\end{document}

--- a/data/varlimits/xelatex.tex
+++ b/data/varlimits/xelatex.tex
@@ -1,0 +1,35 @@
+\documentclass[12pt]{article}
+\usepackage[paperheight=105mm,paperwidth=74mm,margin=4mm]{geometry}
+\pagenumbering{gobble}
+\setlength{\parindent}{0pt}
+\usepackage{libertinus}
+\usepackage{fontspec}
+\usepackage{unicode-math}
+\begin{document}
+
+$$
+  \projlim_{i \in I} A_i = \varprojlim_{i \in I} A_i
+$$
+
+Inline: $\projlim_{i \in I} A_i = \varprojlim_{i \in I} A_i$
+
+
+$$
+  \injlim_{i \in I} A_i = \varinjlim_{i \in I} A_i
+$$
+
+Inline: $\injlim_{i \in I} A_i = \varinjlim_{i \in I} A_i$
+
+$$
+  \limsup_{n \to \infty} a_n = \varlimsup_{n \to \infty} a_n
+$$
+
+Inline: $\limsup_{n \to \infty} a_n = \varlimsup_{n \to \infty} a_n$
+
+$$
+  \liminf_{n \to \infty} a_n = \varliminf_{n \to \infty} a_n
+$$
+
+Inline: $\liminf_{n \to \infty} a_n = \varliminf_{n \to \infty} a_n$
+
+\end{document}


### PR DESCRIPTION
A proposal.

I check the SIL file with SILE v0.15.9.
I didn't run polytype locally, but checked the LaTeX file with Overleaf (and XeLaTeX selected as its engine).

I've no idea on how to do this in Typst, but if deemed needed, I can ask either on their Discord or elsewhere.
It's possible it might not be straight-forward (out-of-the-box), needing [some macros](https://forum.typst.app/t/how-to-create-the-colimit-symbol-varinjlim/2366). I dunno, I am not yet a convinced Typst user :smile_cat: 